### PR TITLE
Opened up Naval italy focuses

### DIFF
--- a/common/national_focus/italy.txt
+++ b/common/national_focus/italy.txt
@@ -2788,7 +2788,7 @@ focus_tree = {
 		relative_position_id = ITA_steel_industry_in_terni
 		cost = 5
 		available = {
-			has_tech = synth_oil_experiments
+			has_tech = advanced_machine_tools
 		}
 
 		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_RESEARCH}
@@ -6233,11 +6233,6 @@ focus_tree = {
 		y = 1
 		relative_position_id = ITA_expand_naval_facilities
 		cost = 5
-		available = {
-			any_enemy_country = {
-				is_major_not_original_tag_root = yes
-			}
-		}
 
 		search_filters = {FOCUS_FILTER_NAVY_XP}
 
@@ -7954,30 +7949,16 @@ focus_tree = {
 			}
 
 			### CORES
-			#ROME
-			if = {
-				limit = {
-					has_full_control_of_state = 2
-				}
-				2 = {
-					add_extra_state_shared_building_slots = 1
-					add_building_construction = {
-						type = dockyard
-						level = 1
-						instant_build = yes
-					}
-				}
-			}
 			#PUGLIA
 			if = {
 				limit = {
 					has_full_control_of_state = 849
 				}
 				849 = {
-					add_extra_state_shared_building_slots = 1
+					add_extra_state_shared_building_slots = 4
 					add_building_construction = {
 						type = dockyard
-						level = 1
+						level = 4
 						instant_build = yes
 					}
 				}
@@ -7988,168 +7969,10 @@ focus_tree = {
 					has_full_control_of_state = 115
 				}
 				115 = {
-					add_extra_state_shared_building_slots = 1
+					add_extra_state_shared_building_slots = 4
 					add_building_construction = {
 						type = dockyard
-						level = 1
-						instant_build = yes
-					}
-				}
-			}
-
-			### COLONIES
-			#TRIPOLI
-			if = {
-				limit = {
-					has_full_control_of_state = 448
-				}
-				448 = {
-					add_extra_state_shared_building_slots = 1
-					add_building_construction = {
-						type = dockyard
-						level = 1
-						instant_build = yes
-					}
-				}
-			}
-			#ERITREA
-			if = {
-				limit = {
-					has_full_control_of_state = 550
-				}
-				550 = {
-					add_extra_state_shared_building_slots = 1
-					add_building_construction = {
-						type = dockyard
-						level = 1
-						instant_build = yes
-					}
-				}
-			}
-			#SOMALILAND
-			if = {
-				limit = {
-					has_full_control_of_state = 559
-				}
-				559 = {
-					add_extra_state_shared_building_slots = 1
-					add_building_construction = {
-						type = dockyard
-						level = 1
-						instant_build = yes
-					}
-				}
-			}
-
-			### EXTRA STUFF
-			#GIBRALTAR
-			if = {
-				limit = {
-					has_full_control_of_state = 118
-				}
-				118 = {
-					add_extra_state_shared_building_slots = 1
-					add_building_construction = {
-						type = dockyard
-						level = 1
-						instant_build = yes
-					}
-				}
-			}
-			#ALGIERS
-			if = {
-				limit = {
-					has_full_control_of_state = 459
-				}
-				459 = {
-					add_extra_state_shared_building_slots = 1
-					add_building_construction = {
-						type = dockyard
-						level = 1
-						instant_build = yes
-					}
-				}
-			}
-			#TUNISIA
-			if = {
-				limit = {
-					has_full_control_of_state = 458
-				}
-				458 = {
-					add_extra_state_shared_building_slots = 1
-					add_building_construction = {
-						type = dockyard
-						level = 1
-						instant_build = yes
-					}
-				}
-			}
-			#ALEXANDRIA
-			if = {
-				limit = {
-					has_full_control_of_state = 447
-				}
-				447 = {
-					add_extra_state_shared_building_slots = 1
-					add_building_construction = {
-						type = dockyard
-						level = 1
-						instant_build = yes
-					}
-				}
-			}
-			#LISBON
-			if = {
-				limit = {
-					has_full_control_of_state = 112
-				}
-				112 = {
-					add_extra_state_shared_building_slots = 1
-					add_building_construction = {
-						type = dockyard
-						level = 1
-						instant_build = yes
-					}
-				}
-			}
-			#SEVILLA
-			if = {
-				limit = {
-					has_full_control_of_state = 169
-				}
-				169 = {
-					add_extra_state_shared_building_slots = 1
-					add_building_construction = {
-						type = dockyard
-						level = 1
-						instant_build = yes
-					}
-				}
-			}
-			#BORDEAUX
-			if = {
-				limit = {
-					has_full_control_of_state = 19
-				}
-				19 = {
-					add_extra_state_shared_building_slots = 1
-					add_building_construction = {
-						type = dockyard
-						level = 1
-						instant_build = yes
-					}
-				}
-			}
-			#BRITTANY
-			if = {
-				limit = {
-					has_full_control_of_state = 14
-				}
-				14 = {
-					add_extra_state_shared_building_slots = 1
-					add_building_construction = {
-						type = dockyard
-						level = 1
+						level = 4
 						instant_build = yes
 					}
 				}


### PR DESCRIPTION
- Changed supermarina not requiring to be major something something
- Flotta d'evasion had its dockyards condensed down to 2 states with both being cores. As 2 states in the original version would always be colonies which resulted in both dockyards being loss to factory access 

Italy can now can 15 dockyards from focus tree around a 3 dockyard buff (buff also includes being able to do it. Additionally another 2 from refit civilian ships (if they spend 70 days for 2 shit converted cruiser hull carriers 

Also Industria della gomma requires tools 3 (advanced machine tools) instead of synthetic oil experiments which should buff Italy slightly in terms of research and a bit of eco